### PR TITLE
Add explicit dynamic product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,9 @@ let package = Package(
     products: [
         .library(
             name: "CoreImageExtensions",
+            targets: ["CoreImageExtensions"]),
+        .library(
+            name: "CoreImageExtensions-dynamic",
             type: .dynamic,
             targets: ["CoreImageExtensions"]),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     products: [
         .library(
             name: "CoreImageExtensions",
+            type: .dynamic,
             targets: ["CoreImageExtensions"]),
     ],
     targets: [


### PR DESCRIPTION
When this package is dependency of a package and a framework it seems to be linked twice. Explicitly using a dynamic product fixes this.