### PR TITLE
Add async CIContext APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ let cgImage = await context.async.createCGImage(ciImage, from: ciImage.extent)
 > **_Note:_**
 > Though they are already asynchronous, even the APIs for working with `CIRenderDestination`, like `startTask(toRender:to:)`, will profit from using the `async` versions.
 > This is because Core Image will perform an analysis of the filter graph that should be applied to the given image _before_ handing the rendering work to the GPU. 
-> Especially for more complex filter pipelines this analysis can be quite costly and is better performed in a background queue to not block the main thread.  
+> Especially for more complex filter pipelines this analysis can be quite costly and is better performed in a background queue to not block the main thread.
+
+We also added async alternatives for the `CIRenderDestination`-related APIs that wait for the task execution and return the `CIRenderInfo` object:
+```swift
+let info = try await context.async.render(image, from: rect, to: destination, at: point)
+let info = try await context.async.render(image, to: destination)
+let info = try await context.async.clear(destination)
+```
 
 ## Image Lookup
 We added a convenience initializer to `CIImage` that you can use to load an image by its name from an asset catalog or from a bundle directly:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Useful extensions for Apple's Core Image framework.
 
+## Async Rendering
+Almost all rendering APIs of `CIContext` are synchronous, i.e., they will block the current thread until rendering is done. In many cases, especially when calling from the main thread, this is undesirable.
+
+We added an extension to `CIContext` that adds `async` versions of all rendering APIs via a wrapping `actor` instance. The actor can be accessed via the `async` property:
+```swift
+let cgImage = await context.async.createCGImage(ciImage, from: ciImage.extent)
+```
+
+> **_Note:_**
+> Though they are already asynchronous, even the APIs for working with `CIRenderDestination`, like `startTask(toRender:to:)`, will profit from using the `async` versions.
+> This is because Core Image will perform an analysis of the filter graph that should be applied to the given image _before_ handing the rendering work to the GPU. 
+> Especially for more complex filter pipelines this analysis can be quite costly and is better performed in a background queue to not block the main thread.  
+
 ## Image Lookup
 We added a convenience initializer to `CIImage` that you can use to load an image by its name from an asset catalog or from a bundle directly:
 ```swift

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ let green: Float32 = value.g // for instance
 These methods come in variants for accessing an area of pixels (in a given `CGRect`) or single pixels (at a given `CGPoint`).
 They are also available for three different data types: `UInt8` (the normal 8-bit per channel format, with [0…255] range), `Float32` (aka `float` containing arbitrary values, but colors are usually mapped to [0...1]), and `Float16` (only on iOS).
 
+> **_Note:_**
+> Also available as `async` versions.
+
 ## OpenEXR Support
 [OpenEXR](https://en.wikipedia.org/wiki/OpenEXR) is an open standard for storing arbitrary bitmap data that exceed “normal” image color data, like 32-bit high-dynamic range data or negative floating point values (for instance for height fields).
 
@@ -87,6 +90,9 @@ try context.writeEXRRepresentation(of: image, to: url, format: .RGBAf)
 ```
 
 For reading EXR files into a `CIImage`, the usual initializers like `CIImage(contentsOf: url)` or `CIImage(named: “myImage.exr”` (see above) can be used.
+
+> **_Note:_**
+> Also available as `async` versions.
 
 ### OpenEXR Test Images
 All EXR test images used in this project have been taken from [here](https://github.com/AcademySoftwareFoundation/openexr-images/).

--- a/Sources/CIContext+Async.swift
+++ b/Sources/CIContext+Async.swift
@@ -158,6 +158,27 @@ public extension CIContext {
             return try self.context.startTask(toClear: destination)
         }
 
+        /// Analogue to ``startTask(toRender:from:to:at:)``, but this one will wait for the task to finish execution and return the resulting `CIRenderInfo` object.
+        @discardableResult
+        public func render(_ image: CIImage, from fromRect: CGRect, to destination: CIRenderDestination, at atPoint: CGPoint) throws -> CIRenderInfo {
+            let task = try self.startTask(toRender: image, from: fromRect, to: destination, at: atPoint)
+            return try task.waitUntilCompleted()
+        }
+
+        /// Analogue to ``startTask(toRender:to:)``, but this one will wait for the task to finish execution and return the resulting `CIRenderInfo` object.
+        @discardableResult
+        public func render(_ image: CIImage, to destination: CIRenderDestination) async throws -> CIRenderInfo {
+            let task = try self.startTask(toRender: image, to: destination)
+            return try task.waitUntilCompleted()
+        }
+
+        /// Analogue to ``startTask(toClear:)``, but this one will wait for the task to finish execution and return the resulting `CIRenderInfo` object.
+        @discardableResult
+        public func clear(_ destination: CIRenderDestination) throws -> CIRenderInfo {
+            let task = try self.startTask(toClear: destination)
+            return try task.waitUntilCompleted()
+        }
+
     }
 
     /// Returns the ``Actor`` instance associated with this context.

--- a/Sources/CIContext+Async.swift
+++ b/Sources/CIContext+Async.swift
@@ -1,0 +1,178 @@
+import CoreImage
+
+
+private var ASSOCIATED_ACTOR_KEY = "CoreImageExtensions.CIContext.async"
+
+
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
+public extension CIContext {
+
+    /// An actor for synchronizing calls to a `CIContext` and executing them in the background.
+    /// The `Actor` instance associated with a context can be accessed via ``CIContext/async``.
+    actor Actor {
+
+        /// The "wrapped" context instance.
+        private weak var context: CIContext!
+
+
+        // MARK: - Lifecycle
+
+        /// Creates a new instance.
+        /// - Parameter ciContext: The `CIContext` to forward all rendering calls to.
+        fileprivate init(_ ciContext: CIContext) {
+            self.context = ciContext
+        }
+
+
+        // MARK: - Drawing
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func draw(_ image: CIImage, in inRect: CGRect, from fromRect: CGRect) {
+            self.context.draw(image, in: inRect, from: fromRect)
+        }
+
+
+        // MARK: - Direct Render
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func render(_ image: CIImage, toBitmap data: UnsafeMutableRawPointer, rowBytes: Int, bounds: CGRect, format: CIFormat, colorSpace: CGColorSpace?) {
+            self.context.render(image, toBitmap: data, rowBytes: rowBytes, bounds: bounds, format: format, colorSpace: colorSpace)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func render(_ image: CIImage, to surface: IOSurfaceRef, bounds: CGRect, colorSpace: CGColorSpace?) {
+            self.context.render(image, to: surface, bounds: bounds, colorSpace: colorSpace)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func render(_ image: CIImage, to buffer: CVPixelBuffer) {
+            self.context.render(image, to: buffer)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func render(_ image: CIImage, to buffer: CVPixelBuffer, bounds: CGRect, colorSpace: CGColorSpace?) {
+            self.context.render(image, to: buffer, bounds: bounds, colorSpace: colorSpace)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func render(_ image: CIImage, to texture: MTLTexture, commandBuffer: MTLCommandBuffer?, bounds: CGRect, colorSpace: CGColorSpace) {
+            self.context.render(image, to: texture, commandBuffer: commandBuffer, bounds: bounds, colorSpace: colorSpace)
+        }
+
+
+        // MARK: - CGImage Creation
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func createCGImage(_ image: CIImage, from fromRect: CGRect) -> CGImage? {
+            return self.context.createCGImage(image, from: fromRect)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func createCGImage(_ image: CIImage, from fromRect: CGRect, format: CIFormat, colorSpace: CGColorSpace?) -> CGImage? {
+            return self.context.createCGImage(image, from: fromRect, format: format, colorSpace: colorSpace)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func createCGImage(_ image: CIImage, from fromRect: CGRect, format: CIFormat, colorSpace: CGColorSpace?, deferred: Bool) -> CGImage? {
+            return self.context.createCGImage(image, from: fromRect, format: format, colorSpace: colorSpace, deferred: deferred)
+        }
+
+
+        // MARK: - Creating Data Representations
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func tiffRepresentation(of image: CIImage, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) -> Data? {
+            return self.context.tiffRepresentation(of: image, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func jpegRepresentation(of image: CIImage, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) -> Data? {
+            return self.context.jpegRepresentation(of: image, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func heifRepresentation(of image: CIImage, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) -> Data? {
+            return self.context.heifRepresentation(of: image, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+        public func heif10Representation(of image: CIImage, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws -> Data {
+            return try self.context.heif10Representation(of: image, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func pngRepresentation(of image: CIImage, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) -> Data? {
+            return self.context.pngRepresentation(of: image, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func writeTIFFRepresentation(of image: CIImage, to url: URL, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws {
+            try self.context.writeTIFFRepresentation(of: image, to: url, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func writePNGRepresentation(of image: CIImage, to url: URL, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws {
+            try self.context.writePNGRepresentation(of: image, to: url, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func writeJPEGRepresentation(of image: CIImage, to url: URL, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws {
+            try self.context.writeJPEGRepresentation(of: image, to: url, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func writeHEIFRepresentation(of image: CIImage, to url: URL, format: CIFormat, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws {
+            try self.context.writeHEIFRepresentation(of: image, to: url, format: format, colorSpace: colorSpace, options: options)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, *)
+        public func writeHEIF10Representation(of image: CIImage, to url: URL, colorSpace: CGColorSpace, options: [CIImageRepresentationOption: Any] = [:]) throws {
+            try self.context.writeHEIF10Representation(of: image, to: url, colorSpace: colorSpace, options: options)
+        }
+
+
+        // MARK: Destination APIs
+
+        /// Async version of the `CIContext` method with the same signature.
+        @discardableResult
+        public func startTask(toRender image: CIImage, from fromRect: CGRect, to destination: CIRenderDestination, at atPoint: CGPoint) throws -> CIRenderTask {
+            return try self.context.startTask(toRender: image, from: fromRect, to: destination, at: atPoint)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        @discardableResult
+        public func startTask(toRender image: CIImage, to destination: CIRenderDestination) throws -> CIRenderTask {
+            return try self.context.startTask(toRender: image, to: destination)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        public func prepareRender(_ image: CIImage, from fromRect: CGRect, to destination: CIRenderDestination, at atPoint: CGPoint) throws {
+            try self.context.prepareRender(image, from: fromRect, to: destination, at: atPoint)
+        }
+
+        /// Async version of the `CIContext` method with the same signature.
+        @discardableResult
+        public func startTask(toClear destination: CIRenderDestination) throws -> CIRenderTask {
+            return try self.context.startTask(toClear: destination)
+        }
+
+    }
+
+    /// Returns the ``Actor`` instance associated with this context.
+    /// Calls to the actor will be forwarded to the context, but their execution
+    /// will be synchronized and happen asynchronous in the background.
+    var async: Actor {
+        // check if we already have an Actor created for this context...
+        if let actor = objc_getAssociatedObject(self, &ASSOCIATED_ACTOR_KEY) as? Actor {
+            return actor
+        // ... otherwise create a new one and safe it as associated object
+        } else {
+            let actor = Actor(self)
+            objc_setAssociatedObject(self, &ASSOCIATED_ACTOR_KEY, actor, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            return actor
+        }
+    }
+
+}

--- a/Sources/CIContext+Async.swift
+++ b/Sources/CIContext+Async.swift
@@ -12,7 +12,7 @@ public extension CIContext {
     actor Actor {
 
         /// The "wrapped" context instance.
-        private weak var context: CIContext!
+        public private(set) weak var context: CIContext!
 
 
         // MARK: - Lifecycle

--- a/Sources/CIContext+EXR.swift
+++ b/Sources/CIContext+EXR.swift
@@ -86,3 +86,19 @@ public extension CIContext {
     }
 
 }
+
+
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
+public extension CIContext.Actor {
+
+    /// Async version of the `CIContext` method with the same signature.
+    func exrRepresentation(of image: CIImage, format: CIFormat, colorSpace: CGColorSpace? = nil, options: [CIImageRepresentationOption: Any] = [:]) throws -> Data {
+        return try self.context.exrRepresentation(of: image, format: format, colorSpace: colorSpace, options: options)
+    }
+
+    /// Async version of the `CIContext` method with the same signature.
+    func writeEXRRepresentation(of image: CIImage, to url: URL, format: CIFormat, colorSpace: CGColorSpace? = nil, options: [CIImageRepresentationOption: Any] = [:]) throws {
+        return try self.context.writeEXRRepresentation(of: image, to: url, format: format, colorSpace: colorSpace, options: options)
+    }
+
+}

--- a/Sources/CIContext+ValueAccess.swift
+++ b/Sources/CIContext+ValueAccess.swift
@@ -104,3 +104,49 @@ extension CIContext {
     }
 
 }
+
+
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
+extension CIContext.Actor {
+
+    /// Async version of the `CIContext` method with the same signature.
+    public func readUInt8PixelValues(from image: CIImage, in rect: CGRect, colorSpace: CGColorSpace? = nil) -> [Pixel<UInt8>] {
+        return self.context.readUInt8PixelValues(from: image, in: rect, colorSpace: colorSpace)
+    }
+
+    /// Async version of the `CIContext` method with the same signature.
+    public func readUInt8PixelValue(from image: CIImage, at point: CGPoint, colorSpace: CGColorSpace? = nil) -> Pixel<UInt8> {
+        return self.context.readUInt8PixelValue(from: image, at: point, colorSpace: colorSpace)
+    }
+
+    /// Async version of the `CIContext` method with the same signature.
+    public func readFloat32PixelValues(from image: CIImage, in rect: CGRect, colorSpace: CGColorSpace? = nil) -> [Pixel<Float32>] {
+        return self.context.readFloat32PixelValues(from: image, in: rect, colorSpace: colorSpace)
+    }
+
+    /// Async version of the `CIContext` method with the same signature.
+    public func readFloat32PixelValue(from image: CIImage, at point: CGPoint, colorSpace: CGColorSpace? = nil) -> Pixel<Float32> {
+        return self.context.readFloat32PixelValue(from: image, at: point, colorSpace: colorSpace)
+    }
+
+    #if (os(iOS) || os(tvOS)) && !targetEnvironment(macCatalyst)
+
+    /// Async version of the `CIContext` method with the same signature.
+    @available(iOS 14, tvOS 14, *)
+    @available(macOS, unavailable)
+    @available(macCatalyst, unavailable)
+    public func readFloat16PixelValues(from image: CIImage, in rect: CGRect, colorSpace: CGColorSpace? = nil) -> [Pixel<Float16>] {
+        return self.context.readFloat16PixelValues(from: image, in: rect, colorSpace: colorSpace)
+    }
+
+    /// Async version of the `CIContext` method with the same signature.
+    @available(iOS 14, tvOS 14, *)
+    @available(macOS, unavailable)
+    @available(macCatalyst, unavailable)
+    public func readFloat16PixelValue(from image: CIImage, at point: CGPoint, colorSpace: CGColorSpace? = nil) -> Pixel<Float16> {
+        return self.context.readFloat16PixelValue(from: image, at: point, colorSpace: colorSpace)
+    }
+
+    #endif
+
+}

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -1,0 +1,34 @@
+import CoreImage
+import CoreImageExtensions
+import XCTest
+
+
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, *)
+class AsyncTests: XCTestCase {
+
+    let context = CIContext()
+
+    let testPixelImage = CIImage.containing(values: CIVector(x: 0.0, y: 0.5, z: 1.0, w: 1.0))!.cropped(to: .singlePixel)
+
+    func testForMemoryLeak() {
+        var context: CIContext? = CIContext()
+        // create actor
+        let _ = context?.async
+        // create weak reference
+        weak var weakContext = context
+        // release context
+        context = nil
+        XCTAssertNil(weakContext, "The context should release properly, even after creating the actor.")
+    }
+
+    func testReadPixelAsync() async {
+        let value = await self.context.async.readUInt8PixelValue(from: testPixelImage, at: .zero)
+        XCTAssertEqual(value, Pixel<UInt8>(x: 0, y: 128, z: 255, w: 255))
+    }
+
+    func testCreateCGImageAsync() async {
+        let cgImage = await self.context.async.createCGImage(testPixelImage, from: .singlePixel)
+        XCTAssertNotNil(cgImage)
+    }
+
+}

--- a/Tests/AsyncTests.swift
+++ b/Tests/AsyncTests.swift
@@ -10,7 +10,7 @@ class AsyncTests: XCTestCase {
 
     let testPixelImage = CIImage.containing(values: CIVector(x: 0.0, y: 0.5, z: 1.0, w: 1.0))!.cropped(to: .singlePixel)
 
-    func testForMemoryLeak() {
+    func testContextRelease() {
         var context: CIContext? = CIContext()
         // create actor
         let _ = context?.async


### PR DESCRIPTION
This adds an `actor` to `CIContext` that enables the `async` execution of its rendering APIs.